### PR TITLE
Add export of private key as hex.

### DIFF
--- a/network/network-identity/src/main/java/bisq/network/identity/TorIdentity.java
+++ b/network/network-identity/src/main/java/bisq/network/identity/TorIdentity.java
@@ -40,6 +40,9 @@ import java.util.Arrays;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString
 public class TorIdentity implements Proto {
+    public static TorIdentity from(byte[] privateKey, int port) {
+        return new TorIdentity(privateKey, port, computeOnionAddressFromPrivateKey(privateKey));
+    }
 
     @ToString.Exclude
     private final byte[] privateKey;


### PR DESCRIPTION
Use persisted tor identity if found in tor hiddenservice dir.

This allows for easy backup and restore of the default tor identity.